### PR TITLE
feat: function call changes

### DIFF
--- a/moonshot-core/src/main/java/org/springframework/ai/moonshot/api/MoonshotConstants.java
+++ b/moonshot-core/src/main/java/org/springframework/ai/moonshot/api/MoonshotConstants.java
@@ -16,8 +16,6 @@
 
 package org.springframework.ai.moonshot.api;
 
-import org.springframework.ai.observation.conventions.AiProvider;
-
 /**
  * Constants for Moonshot API.
  *
@@ -27,7 +25,9 @@ public final class MoonshotConstants {
 
 	public static final String DEFAULT_BASE_URL = "https://api.moonshot.cn";
 
-	public static final String PROVIDER_NAME = AiProvider.MOONSHOT.value();
+	public static final String MOONSHOT_PROVIDER_NAME = "Moonshot";
+
+	public static final String DEFAULT_COMPLETIONS_PATH = "/v1/chat/completions";
 
 	private MoonshotConstants() {
 

--- a/moonshot-core/src/main/java/org/springframework/ai/moonshot/api/MoonshotStreamFunctionCallingHelper.java
+++ b/moonshot-core/src/main/java/org/springframework/ai/moonshot/api/MoonshotStreamFunctionCallingHelper.java
@@ -16,9 +16,6 @@
 
 package org.springframework.ai.moonshot.api;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionChunk;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionChunk.ChunkChoice;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionFinishReason;
@@ -27,6 +24,9 @@ import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage.Cha
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage.Role;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage.ToolCall;
 import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Helper class to support Streaming function calling. It can merge the streamed

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/MoonshotTestConfiguration.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/MoonshotTestConfiguration.java
@@ -29,20 +29,21 @@ public class MoonshotTestConfiguration {
 
 	@Bean
 	public MoonshotApi moonshotApi() {
-		var apiKey = System.getenv("MOONSHOT_API_KEY");
-		if (!StringUtils.hasText(apiKey)) {
-			throw new IllegalArgumentException(
-					"Missing MOONSHOT_API_KEY environment variable. Please set it to your Moonshot API key.");
-		}
-		return new MoonshotApi(apiKey);
+		return MoonshotApi.builder().apiKey(getApiKey()).build();
 	}
 
 	@Bean
-	public MoonshotChatModel moonshotChatModel(MoonshotApi moonshotApi) {
-		return new MoonshotChatModel(moonshotApi);
+	public MoonshotChatModel moonshotChatModel(MoonshotApi api) {
+		return MoonshotChatModel.builder().moonshotApi(api).build();
 	}
 
-	public void tst() {
+	private String getApiKey() {
+		String apiKey = System.getenv("MOONSHOT_API_KEY");
+		if (!StringUtils.hasText(apiKey)) {
+			throw new IllegalArgumentException(
+					"You must provide an API key.  Put it in an environment variable under the name MOONSHOT_API_KEY");
+		}
+		return apiKey;
 	}
 
 }

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/aot/MoonshotRuntimeHintsTests.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/aot/MoonshotRuntimeHintsTests.java
@@ -16,15 +16,14 @@
 
 package org.springframework.ai.moonshot.aot;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
-
 import org.springframework.ai.moonshot.MoonshotChatOptions;
 import org.springframework.ai.moonshot.api.MoonshotApi;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.springframework.ai.aot.AiRuntimeHints.findJsonAnnotatedClassesInPackage;

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/api/MockWeatherService.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/api/MockWeatherService.java
@@ -16,13 +16,13 @@
 
 package org.springframework.ai.moonshot.api;
 
-import java.util.function.Function;
-
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import java.util.function.Function;
 
 /**
  * @author Geng Rong

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/api/MoonshotApiIT.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/api/MoonshotApiIT.java
@@ -16,18 +16,17 @@
 
 package org.springframework.ai.moonshot.api;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import reactor.core.publisher.Flux;
-
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletion;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionChunk;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage.Role;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionRequest;
 import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "MOONSHOT_API_KEY", matches = ".+")
 public class MoonshotApiIT {
 
-	MoonshotApi moonshotApi = new MoonshotApi(System.getenv("MOONSHOT_API_KEY"));
+	MoonshotApi moonshotApi = MoonshotApi.builder().apiKey(System.getenv("MOONSHOT_API_KEY")).build();
 
 	@Test
 	void chatCompletionEntity() {
@@ -57,7 +56,7 @@ public class MoonshotApiIT {
 				You are an AI assistant that helps people find information.
 				Your name is Bob.
 				You should reply to the user's request with your name and also in the style of a pirate.
-					""", Role.SYSTEM);
+				""", Role.SYSTEM);
 
 		ResponseEntity<ChatCompletion> response = this.moonshotApi.chatCompletionEntity(new ChatCompletionRequest(
 				List.of(systemMessage, userMessage), MoonshotApi.ChatModel.MOONSHOT_V1_8K.getValue(), 0.8, false));

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/api/MoonshotApiToolFunctionCallIT.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/api/MoonshotApiToolFunctionCallIT.java
@@ -16,17 +16,12 @@
 
 package org.springframework.ai.moonshot.api;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletion;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage;
 import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionMessage.Role;
@@ -36,6 +31,10 @@ import org.springframework.ai.moonshot.api.MoonshotApi.ChatCompletionRequest.Too
 import org.springframework.ai.moonshot.api.MoonshotApi.FunctionTool;
 import org.springframework.ai.moonshot.api.MoonshotApi.FunctionTool.Type;
 import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,7 +74,7 @@ public class MoonshotApiToolFunctionCallIT {
 
 	private final MockWeatherService weatherService = new MockWeatherService();
 
-	private final MoonshotApi moonshotApi = new MoonshotApi(System.getenv("MOONSHOT_API_KEY"));
+	MoonshotApi moonshotApi = MoonshotApi.builder().apiKey(System.getenv("MOONSHOT_API_KEY")).build();
 
 	private static <T> T fromJson(String json, Class<T> targetClass) {
 		try {

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelFunctionCallingIT.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelFunctionCallingIT.java
@@ -16,18 +16,10 @@
 
 package org.springframework.ai.moonshot.chat;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
-
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -35,13 +27,19 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.moonshot.MoonshotChatOptions;
 import org.springframework.ai.moonshot.MoonshotTestConfiguration;
 import org.springframework.ai.moonshot.api.MockWeatherService;
 import org.springframework.ai.moonshot.api.MoonshotApi;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -91,8 +89,7 @@ class MoonshotChatModelFunctionCallingIT {
 
 		var promptOptions = MoonshotChatOptions.builder()
 			.model(MoonshotApi.ChatModel.MOONSHOT_V1_8K.getValue())
-			.functionCallbacks(List.of(FunctionCallback.builder()
-				.function("getCurrentWeather", new MockWeatherService())
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get the weather in location")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
@@ -114,8 +111,7 @@ class MoonshotChatModelFunctionCallingIT {
 		List<Message> messages = new ArrayList<>(List.of(userMessage));
 
 		var promptOptions = MoonshotChatOptions.builder()
-			.functionCallbacks(List.of(FunctionCallback.builder()
-				.function("getCurrentWeather", new MockWeatherService())
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get the weather in location")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
@@ -141,9 +137,7 @@ class MoonshotChatModelFunctionCallingIT {
 	public void toolFunctionCallWithUsage() {
 		var promptOptions = MoonshotChatOptions.builder()
 			.model(MoonshotApi.ChatModel.MOONSHOT_V1_8K.getValue())
-			.tools(Arrays.asList(FUNCTION_TOOL))
-			.functionCallbacks(List.of(FunctionCallback.builder()
-				.function("getCurrentWeather", new MockWeatherService())
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get the weather in location. Return temperature in 36°F or 36°C format.")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
@@ -155,17 +149,15 @@ class MoonshotChatModelFunctionCallingIT {
 		assertThat(chatResponse).isNotNull();
 		assertThat(chatResponse.getResult().getOutput());
 		assertThat(chatResponse.getResult().getOutput().getText()).contains("San Francisco");
-		assertThat(chatResponse.getResult().getOutput().getText()).contains("30.0");
-		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isLessThan(450).isGreaterThan(280);
+		assertThat(chatResponse.getResult().getOutput().getText()).contains("30");
+		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isLessThan(700).isGreaterThan(280);
 	}
 
 	@Test
 	public void testStreamFunctionCallUsage() {
 		var promptOptions = MoonshotChatOptions.builder()
 			.model(MoonshotApi.ChatModel.MOONSHOT_V1_8K.getValue())
-			.tools(Arrays.asList(FUNCTION_TOOL))
-			.functionCallbacks(List.of(FunctionCallback.builder()
-				.function("getCurrentWeather", new MockWeatherService())
+			.toolCallbacks(List.of(FunctionToolCallback.builder("getCurrentWeather", new MockWeatherService())
 				.description("Get the weather in location. Return temperature in 36°F or 36°C format.")
 				.inputType(MockWeatherService.Request.class)
 				.build()))
@@ -177,7 +169,7 @@ class MoonshotChatModelFunctionCallingIT {
 		assertThat(chatResponse).isNotNull();
 		assertThat(chatResponse.getMetadata()).isNotNull();
 		assertThat(chatResponse.getMetadata().getUsage()).isNotNull();
-		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isLessThan(450).isGreaterThan(280);
+		assertThat(chatResponse.getMetadata().getUsage().getTotalTokens()).isLessThan(700).isGreaterThan(280);
 	}
 
 }

--- a/moonshot-core/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelIT.java
+++ b/moonshot-core/src/test/java/org/springframework/ai/moonshot/chat/MoonshotChatModelIT.java
@@ -16,16 +16,10 @@
 
 package org.springframework.ai.moonshot.chat;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -45,6 +39,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.Resource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,8 +87,10 @@ public class MoonshotChatModelIT {
 				List five {subject}
 				{format}
 				""";
-		PromptTemplate promptTemplate = new PromptTemplate(template,
-				Map.of("subject", "ice cream flavors", "format", format));
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template(template)
+			.variables(Map.of("subject", "ice cream flavors", "format", format))
+			.build();
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
@@ -109,12 +110,12 @@ public class MoonshotChatModelIT {
 				Provide me a List of {subject}
 				{format}
 				""";
-		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("subject", """
+		PromptTemplate promptTemplate = PromptTemplate.builder().template(template).variables(Map.of("subject", """
 				numbers from 1 to 9 under they key name 'numbers'.
 				For example here is a list of numbers from 1 to 3 the required format
 					{
 					"numbers": [1, 2, 3]
-					}""", "format", format));
+					}""", "format", format)).build();
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
@@ -133,7 +134,10 @@ public class MoonshotChatModelIT {
 				Generate the filmography for a random actor.
 				{format}
 				""";
-		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template(template)
+			.variables(Map.of("format", format))
+			.build();
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
@@ -158,7 +162,10 @@ public class MoonshotChatModelIT {
 
 				Your response should be without ```json``` and $schema
 				""";
-		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template(template)
+			.variables(Map.of("format", format))
+			.build();
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 		Generation generation = this.chatModel.call(prompt).getResult();
 
@@ -180,7 +187,10 @@ public class MoonshotChatModelIT {
 
 				your response should be without ```json``` and $shcema.
 				""";
-		PromptTemplate promptTemplate = new PromptTemplate(template, Map.of("format", format));
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template(template)
+			.variables(Map.of("format", format))
+			.build();
 		Prompt prompt = new Prompt(promptTemplate.createMessage());
 
 		String generationTextFromStream = this.streamingChatModel.stream(prompt)

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Dependency versions -->
-        <spring-framework.version>6.1.4</spring-framework.version>
-        <spring-ai.version>1.0.0-M7</spring-ai.version>
+        <spring-framework.version>6.2.6</spring-framework.version>
+        <spring-ai.version>1.0.0-M8</spring-ai.version>
         <micrometer.version>1.12.2</micrometer.version>
         <reactor.version>2023.0.2</reactor.version>
         <slf4j.version>2.0.9</slf4j.version>
@@ -57,6 +57,8 @@
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+
+        <spring-javaformat-maven-plugin.version>0.0.43</spring-javaformat-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -102,6 +104,11 @@
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-autoconfigure-retry</artifactId>
+                <version>${spring-ai.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-autoconfigure-model-tool</artifactId>
                 <version>${spring-ai.version}</version>
             </dependency>
             <dependency>
@@ -218,6 +225,20 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>io.spring.javaformat</groupId>
+                <artifactId>spring-javaformat-maven-plugin</artifactId>
+                <version>${spring-javaformat-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <inherited>true</inherited>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/spring-ai-autoconfigure-model-moonshot/pom.xml
+++ b/spring-ai-autoconfigure-model-moonshot/pom.xml
@@ -30,6 +30,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-tool</artifactId>
+        </dependency>
+
         <!-- Spring AI dependencies -->
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/spring-ai-autoconfigure-model-moonshot/src/main/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotChatProperties.java
+++ b/spring-ai-autoconfigure-model-moonshot/src/main/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotChatProperties.java
@@ -21,6 +21,8 @@ import org.springframework.ai.moonshot.api.MoonshotApi;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
+import static org.springframework.ai.moonshot.api.MoonshotConstants.DEFAULT_COMPLETIONS_PATH;
+
 /**
  * Configuration properties for Moonshot chat client.
  *
@@ -36,6 +38,8 @@ public class MoonshotChatProperties extends MoonshotParentProperties {
 
 	private static final Double DEFAULT_TEMPERATURE = 0.7;
 
+	private String completionsPath = DEFAULT_COMPLETIONS_PATH;
+
 	@NestedConfigurationProperty
 	private MoonshotChatOptions options = MoonshotChatOptions.builder()
 		.model(DEFAULT_CHAT_MODEL)
@@ -48,6 +52,14 @@ public class MoonshotChatProperties extends MoonshotParentProperties {
 
 	public void setOptions(MoonshotChatOptions options) {
 		this.options = options;
+	}
+
+	public String getCompletionsPath() {
+		return completionsPath;
+	}
+
+	public void setCompletionsPath(String completionsPath) {
+		this.completionsPath = completionsPath;
 	}
 
 }

--- a/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotChatAutoConfigurationIT.java
+++ b/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotChatAutoConfigurationIT.java
@@ -16,15 +16,10 @@
 
 package org.springframework.ai.model.moonshot.autoconfigure;
 
-import java.util.Objects;
-import java.util.stream.Collectors;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import reactor.core.publisher.Flux;
-
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -33,6 +28,10 @@ import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import reactor.core.publisher.Flux;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotPropertiesTests.java
+++ b/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/MoonshotPropertiesTests.java
@@ -17,7 +17,6 @@
 package org.springframework.ai.model.moonshot.autoconfigure;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.ai.moonshot.MoonshotChatModel;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;

--- a/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/tool/FunctionCallbackInPromptIT.java
+++ b/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/tool/FunctionCallbackInPromptIT.java
@@ -16,28 +16,27 @@
 
 package org.springframework.ai.model.moonshot.autoconfigure.tool;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
-
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.model.moonshot.autoconfigure.MoonshotChatAutoConfiguration;
 import org.springframework.ai.moonshot.MoonshotChatModel;
 import org.springframework.ai.moonshot.MoonshotChatOptions;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
+import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,8 +64,7 @@ public class FunctionCallbackInPromptIT {
 					"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius");
 
 			var promptOptions = MoonshotChatOptions.builder()
-				.functionCallbacks(List.of(FunctionCallback.builder()
-					.function("CurrentWeatherService", new MockWeatherService())
+				.toolCallbacks(List.of(FunctionToolCallback.builder("CurrentWeatherService", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
 					.build()))
@@ -91,8 +89,7 @@ public class FunctionCallbackInPromptIT {
 					"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius");
 
 			var promptOptions = MoonshotChatOptions.builder()
-				.functionCallbacks(List.of(FunctionCallback.builder()
-					.function("CurrentWeatherService", new MockWeatherService())
+				.toolCallbacks(List.of(FunctionToolCallback.builder("CurrentWeatherService", new MockWeatherService())
 					.description("Get the weather in location")
 					.inputType(MockWeatherService.Request.class)
 					.build()))

--- a/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
+++ b/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/tool/FunctionCallbackWithPlainFunctionBeanIT.java
@@ -16,23 +16,17 @@
 
 package org.springframework.ai.model.moonshot.autoconfigure.tool;
 
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
-
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.model.function.FunctionCallingOptions;
 import org.springframework.ai.model.moonshot.autoconfigure.MoonshotChatAutoConfiguration;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.moonshot.MoonshotChatModel;
 import org.springframework.ai.moonshot.MoonshotChatOptions;
 import org.springframework.ai.retry.autoconfigure.SpringAiRetryAutoConfiguration;
@@ -42,6 +36,11 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Description;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,7 +70,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 					"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius");
 
 			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage),
-					MoonshotChatOptions.builder().function("weatherFunction").build()));
+					MoonshotChatOptions.builder().toolNames("weatherFunction").build()));
 
 			logger.info("Response: {}", response);
 
@@ -79,7 +78,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			// Test weatherFunctionTwo
 			response = chatModel.call(new Prompt(List.of(userMessage),
-					MoonshotChatOptions.builder().function("weatherFunctionTwo").build()));
+					MoonshotChatOptions.builder().toolNames("weatherFunctionTwo").build()));
 
 			logger.info("Response: {}", response);
 
@@ -98,8 +97,8 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 			UserMessage userMessage = new UserMessage(
 					"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius");
 
-			FunctionCallingOptions functionOptions = FunctionCallingOptions.builder()
-				.function("weatherFunction")
+			ToolCallingChatOptions functionOptions = ToolCallingChatOptions.builder()
+				.toolNames("weatherFunction")
 				.build();
 
 			ChatResponse response = chatModel.call(new Prompt(List.of(userMessage), functionOptions));
@@ -119,7 +118,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 					"What's the weather like in San Francisco, Tokyo, and Paris? Return the temperature in Celsius");
 
 			Flux<ChatResponse> response = chatModel.stream(new Prompt(List.of(userMessage),
-					MoonshotChatOptions.builder().function("weatherFunction").build()));
+					MoonshotChatOptions.builder().toolNames("weatherFunction").build()));
 
 			String content = response.collectList()
 				.block()
@@ -137,7 +136,7 @@ class FunctionCallbackWithPlainFunctionBeanIT {
 
 			// Test weatherFunctionTwo
 			response = chatModel.stream(new Prompt(List.of(userMessage),
-					MoonshotChatOptions.builder().function("weatherFunctionTwo").build()));
+					MoonshotChatOptions.builder().toolNames("weatherFunctionTwo").build()));
 
 			content = response.collectList()
 				.block()

--- a/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/tool/MockWeatherService.java
+++ b/spring-ai-autoconfigure-model-moonshot/src/test/java/org/springframework/ai/model/moonshot/autoconfigure/tool/MockWeatherService.java
@@ -16,13 +16,13 @@
 
 package org.springframework.ai.model.moonshot.autoconfigure.tool;
 
-import java.util.function.Function;
-
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import java.util.function.Function;
 
 /**
  * Mock 3rd party weather service.


### PR DESCRIPTION
the function call changes:

1) The ChatOptions would extend from ToolCallingChatOptions instead of FunctionCallingOptions
2) The flag proxyToolCalls is replaced by the internalToolExecutionsEnabled to check if the tool execution is handled by Spring AI (this is set to true by default)
3) All the functionCallback options are replaced by toolCallback and toolNames
4) The ChatModel no longer extends from AbstractToolCallSupport but has the toolCallingManager reference to execute the tools
5) There is ToolExecutionEligibilityPredicate which handles the delegation to verify the enabling of tool execution. 